### PR TITLE
add description parameter so diagnostic events will report dataStoreType as "Consul"

### DIFF
--- a/consul_feature_store.js
+++ b/consul_feature_store.js
@@ -12,7 +12,7 @@ function ConsulFeatureStore(options) {
   if (ttl === null || ttl === undefined) {
     ttl = defaultCacheTTLSeconds;
   }
-  return new CachingStoreWrapper(consulFeatureStoreInternal(options), ttl);
+  return new CachingStoreWrapper(consulFeatureStoreInternal(options), ttl, 'Consul');
 }
 
 function consulFeatureStoreInternal(options) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint-formatter-pretty": "1.3.0",
     "jest": "24.7.1",
     "jest-junit": "6.3.0",
+    "launchdarkly-js-test-helpers": "^1.0.0",
     "launchdarkly-node-server-sdk": ">= 5.8.1",
     "typescript": "3.0.1"
   },


### PR DESCRIPTION
With older versions of the Node SDK this parameter will just ignored, so I did not increase the peer dependency version. It just means we will get more accurate config data when diagnostic events are supported and enabled.