### PR TITLE
prepare 2.0.0-rc.1 release

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules/
 test-types.js
+.eslintrc.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the LaunchDarkly Node.js SDK Consul integration will be d
 
 ## [2.0.0-rc.1] - 2021-06-15
 
-_This is a release candidate version corresponding to the current projected state of the 3.0.0 release. The final 2.0.0 release may include additional functionality or fixes._
+_This is a release candidate version corresponding to the current projected state of the 2.0.0 release. The final 2.0.0 release may include additional functionality or fixes._
 
 The 2.0.0 release of `launchdarkly-node-server-sdk-consul` is for use with version 6.x of the LaunchDarkly server-side SDK for Node.js. It has the same functionality as the previous major version, but its dependencies, Node version compatibility, and internal API have been updated to match the 6.0.0 release of the SDK.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the LaunchDarkly Node.js SDK Consul integration will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.0.0-rc.1] - 2021-06-15
+
+_This is a release candidate version corresponding to the current projected state of the 3.0.0 release. The final 2.0.0 release may include additional functionality or fixes._
+
+The 2.0.0 release of `launchdarkly-node-server-sdk-consul` is for use with version 6.x of the LaunchDarkly server-side SDK for Node.js. It has the same functionality as the previous major version, but its dependencies, Node version compatibility, and internal API have been updated to match the 6.0.0 release of the SDK.
+
+This version uses the same Consul client package as previous releases.
+
 ## [1.0.5] - 2020-03-25
 ### Removed:
 - The package dependencies mistakenly included `typedoc`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to this library
+
+The source code for this library is [here](https://github.com/launchdarkly/node-server-sdk-consul). We encourage pull-requests and other contributions from the community. Since this library is meant to be used in conjunction with the LaunchDarkly Server-Side Node.js SDK, you may want to look at the [SDK source code](https://github.com/launchdarkly/dotnet-server-sdk) and our [SDK contributor's guide](http://docs.launchdarkly.com/docs/sdk-contributors-guide).
+
+## Submitting bug reports and feature requests
+ 
+The LaunchDarkly SDK team monitors the [issue tracker](https://github.com/launchdarkly/node-server-sdk-consul/issues) in this repository. Bug reports and feature requests specific to this project should be filed in the issue tracker. The SDK team will respond to all newly filed issues within two business days.
+ 
+## Submitting pull requests
+ 
+We encourage pull requests and other contributions from the community. Before submitting pull requests, ensure that all temporary or unintended code is removed. Don't worry about adding reviewers to the pull request; the LaunchDarkly SDK team will add themselves. The SDK team will acknowledge all pull requests within two business days.
+ 
+## Build instructions
+ 
+### Prerequisites
+
+The project uses `npm`, which is bundled in all supported versions of Node. It should be built against the lowest compatible version, Node 12.
+
+### Setup
+
+To install project dependencies, from the project root directory:
+
+```
+npm install
+```
+
+### Testing
+
+To run all unit tests:
+
+```
+npm test
+```
+
+The tests expect you to have Consul running locally. A simple way to do this is with Docker:
+
+```bash
+docker run -p 8500:8500 consul
+```
+
+To verify that the TypeScript declarations compile correctly (this involves compiling the file `test-types.ts`, so if you have changed any types or interfaces, you will want to update that code):
+
+```
+npm run check-typescript
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launchdarkly-node-server-sdk-consul",
-  "version": "1.0.5",
+  "version": "2.0.0-rc.1",
   "description": "Consul-backed feature store for the LaunchDarkly Node.js SDK",
   "main": "consul_feature_store.js",
   "license": "Apache-2.0",
@@ -11,16 +11,20 @@
   },
   "types": "./index.d.ts",
   "devDependencies": {
-    "@babel/core": "^7.4.3",
-    "@babel/preset-env": "^7.4.3",
-    "babel-jest": "^24.7.1",
-    "eslint": "^6.5.1",
-    "eslint-formatter-pretty": "^3.0.1",
-    "jest": "^24.7.1",
-    "jest-junit": "^6.3.0",
-    "launchdarkly-js-test-helpers": "^1.0.0",
-    "launchdarkly-node-server-sdk": "^6.0.0-alpha.1",
-    "typescript": "^3.8.3"
+    "@babel/core": "^7.14.6",
+    "@babel/preset-env": "^7.14.5",
+    "@types/node": "^15.12.2",
+    "babel-jest": "^27.0.2",
+    "eslint": "^7.28.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-formatter-pretty": "^4.1.0",
+    "eslint-plugin-prettier": "^3.4.0",
+    "jest": "^27.0.4",
+    "jest-junit": "^12.2.0",
+    "launchdarkly-js-test-helpers": "^1.2.1",
+    "launchdarkly-node-server-sdk": "^6.0.0-rc.1",
+    "prettier": "^2.3.1",
+    "typescript": "^4.3.2"
   },
   "jest": {
     "rootDir": ".",
@@ -36,7 +40,7 @@
     "node-cache": "4.2.0"
   },
   "peerDependencies": {
-    "launchdarkly-node-server-sdk": "^6.0.0-alpha.1"
+    "launchdarkly-node-server-sdk": "^6.0.0-rc.1"
   },
   "engines": {
     "node": ">= 12.0"


### PR DESCRIPTION
## [2.0.0-rc.1] - 2021-06-15

_This is a release candidate version corresponding to the current projected state of the 2.0.0 release. The final 2.0.0 release may include additional functionality or fixes._

The 2.0.0 release of `launchdarkly-node-server-sdk-consul` is for use with version 6.x of the LaunchDarkly server-side SDK for Node.js. It has the same functionality as the previous major version, but its dependencies, Node version compatibility, and internal API have been updated to match the 6.0.0 release of the SDK.

This version uses the same Consul client package as previous releases.